### PR TITLE
Fix check for verilog parameters

### DIFF
--- a/verilog.py
+++ b/verilog.py
@@ -202,5 +202,6 @@ class ModuleReader:
       module.instances[instance.name] = instance
 
   def LoadParamList(module: Module, ast_node: ast.Node):
-    print('{} has a param list, which we ignore'.format(module))
+    if len(ast_node.children()):
+        print('{} has a param list, which we ignore'.format(module))
 


### PR DESCRIPTION
bigspicy always prints a warning that verilog modules have parameters,
even if they don't.

With this patch we correctly print the warning when there are parameters:

```
cat << EOF > test1.v
module test1 #(
    parameter FOO = 1
);
endmodule
EOF
./bigspicy.py --import --verilog test1.v --top test1
```

And don't print the warning when there are no parameters:

```
cat << EOF > test2.v
module test2 (
);
endmodule
EOF
./bigspicy.py --import --verilog test2.v --top test2
```